### PR TITLE
中黒を入力できるようにする

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 80,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kana-layout-extension",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "タイピングゲームでかな入力配列を使うためのChrome拡張機能です",
   "scripts": {
     "dev": "vite",

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -109,17 +109,16 @@ function handleKeyDown(event: KeyboardEvent, tsukiLayout: TsukiLayout) {
  * ストレージから設定を読み込む
  */
 async function loadSettings(): Promise<Settings> {
-  const result = await chrome.storage.sync.get([
-    "enabled",
-    "keyboardLayout",
-    "kanaLayout",
-  ]);
-  const settings: Settings = {
-    enabled: result.enabled ?? defaultSettings.enabled,
-    keyboardLayout: result.keyboardLayout ?? defaultSettings.keyboardLayout,
-    kanaLayout: result.kanaLayout ?? defaultSettings.kanaLayout,
-  };
-  return settings;
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(null, (result) => {
+      const settings: Settings = {
+        enabled: result.enabled ?? defaultSettings.enabled,
+        keyboardLayout: result.keyboardLayout ?? defaultSettings.keyboardLayout,
+        kanaLayout: result.kanaLayout ?? defaultSettings.kanaLayout,
+      };
+      resolve(settings);
+    });
+  });
 }
 
 /**

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -50,12 +50,12 @@ function handleKeyDown(event: KeyboardEvent, tsukiLayout: TsukiLayout) {
   }
 
   // キー入力の変換処理
-  if (tsukiLayout.isValidKey(event.key)) {
+  if (tsukiLayout.isValidKey(event.code)) {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
 
-    const result = tsukiLayout.process({ state: app.state, key: event.key });
+    const result = tsukiLayout.process({ state: app.state, key: event.code });
     app.state = result.state;
 
     if (result.event !== undefined) {
@@ -130,7 +130,7 @@ function syncAppWithSettings(app: Application): Application {
 
   if (app.settings && app.settings.enabled) {
     // イベントハンドラを設定する
-    const layout = makeTsukiLayout(app.settings.keyboardLayout);
+    const layout = makeTsukiLayout();
     const handler = (event: KeyboardEvent) => handleKeyDown(event, layout);
     window.addEventListener("keydown", handler, true);
 

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -66,7 +66,7 @@ function handleKeyDown(event: KeyboardEvent, tsukiLayout: TsukiLayout) {
           keyCode: result.event.keyCode,
           shiftKey: result.event.shift,
           bubbles: true,
-        })
+        }),
       );
     }
 
@@ -113,7 +113,6 @@ async function loadSettings(): Promise<Settings> {
     chrome.storage.sync.get(null, (result) => {
       const settings: Settings = {
         enabled: result.enabled ?? defaultSettings.enabled,
-        keyboardLayout: result.keyboardLayout ?? defaultSettings.keyboardLayout,
         kanaLayout: result.kanaLayout ?? defaultSettings.kanaLayout,
       };
       resolve(settings);
@@ -136,7 +135,7 @@ function syncAppWithSettings(app: Application): Application {
 
     // e-typingのフレームを監視する
     const isEtypingIframe = window.location.href.includes(
-      "/jsa_kana/typing.asp"
+      "/jsa_kana/typing.asp",
     );
     if (isEtypingIframe) {
       const etypingApp = document.getElementById("app");
@@ -247,10 +246,6 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
     if (!app.settings) return;
     if (changes.enabled) {
       app.settings.enabled = changes.enabled.newValue;
-    }
-
-    if (changes.keyboardLayout) {
-      app.settings.keyboardLayout = changes.keyboardLayout.newValue;
     }
 
     if (changes.kanaLayout) {

--- a/src/keyguide.ts
+++ b/src/keyguide.ts
@@ -176,7 +176,7 @@ export function createKanaKeyboard(keyLayout: KeyLayout): HTMLDivElement {
  * 指のガイドを作成する
  */
 export function createHandsChildren(
-  fingerHighlights: Finger[]
+  fingerHighlights: Finger[],
 ): HTMLDivElement[] {
   const fingers: { finger: Finger; classes: string[] }[] = [
     { finger: "left_little", classes: ["finger", "little", "left"] },
@@ -208,7 +208,7 @@ export function createHandsChildren(
  */
 export function updateHandsHighlights(
   handsElement: HTMLElement,
-  fingerHighlights: Finger[]
+  fingerHighlights: Finger[],
 ): void {
   handsElement.innerHTML = "";
 
@@ -257,7 +257,7 @@ const normalLayout: KeyLayout = {
  * KeyPosition → EtypingKeyPosition の変換
  */
 function keyPositionToEtyping(
-  position: KeyPosition
+  position: KeyPosition,
 ): EtypingKeyPosition | undefined {
   if (position === "space") {
     return "key_space";
@@ -393,10 +393,10 @@ export const tsukiLayoutLayers = {
  */
 export function applyHighlights(
   layerId: "normal" | "leftShifted" | "rightShifted",
-  highlights: KeyPosition[]
+  highlights: KeyPosition[],
 ): HTMLDivElement {
   const keyboardElement = tsukiLayoutLayers[layerId].cloneNode(
-    true
+    true,
   ) as HTMLDivElement;
 
   highlights.forEach((position) => {

--- a/src/layouts/tsuki-2-263-keyguide.ts
+++ b/src/layouts/tsuki-2-263-keyguide.ts
@@ -178,7 +178,7 @@ const keyInfo = {
  */
 function getKeyGuideHightlights(
   state: State,
-  nextCharacter: string | undefined
+  nextCharacter: string | undefined,
 ): KeyPosition[] {
   if (nextCharacter === undefined) return [];
   if (!(nextCharacter in keyInfo)) return [];

--- a/src/layouts/tsuki-2-263-keyguide.ts
+++ b/src/layouts/tsuki-2-263-keyguide.ts
@@ -78,7 +78,10 @@ const keyPositionMap = {
 export type UpdateKeyGuide = (args: {
   state: State;
   restCharacters: string;
-}) => { layerId: KeyboardLayerId; highlights: KeyPosition[] };
+}) => {
+  layerId: KeyboardLayerId;
+  highlights: KeyPosition[];
+};
 
 /**
  * キーガイドのレイヤーIDを計算する

--- a/src/layouts/tsuki-2-263-keyguide.ts
+++ b/src/layouts/tsuki-2-263-keyguide.ts
@@ -120,6 +120,8 @@ const keyInfo = {
   た: { position: [1, 4], side: "left", shift: false },
   く: { position: [1, 5], side: "right", shift: false },
   う: { position: [1, 6], side: "right", shift: false },
+  // https://github.com/tekihei2317/kana-layout-extension/issues/10
+  ウ: { position: [1, 6], side: "right", shift: false },
   // "★": { position: [1, 7], side: "right", shift: false },
   "゛": { position: [1, 8], side: "right", shift: false },
   き: { position: [1, 9], side: "right", shift: false },

--- a/src/layouts/tsuki-2-263.ts
+++ b/src/layouts/tsuki-2-263.ts
@@ -2,76 +2,59 @@ import { InputProcessor } from "../input-processor";
 import { convertKanaToEvent } from "../typing-event";
 import { updateKeyGuide, UpdateKeyGuide } from "./tsuki-2-263-keyguide";
 
-type KeyboardLayoutKind = "JIS" | "US";
-
 type KeymapEntry = { default: string; shift: string; side: "left" | "right" };
 
-function createKeymap(
-  keyboardLayout: KeyboardLayoutKind
-): Record<string, KeymapEntry> {
-  const layouts = {
-    JIS: ["qwertyuiop@", "asdfghjkl;:", "zxcvbnm,./"],
-    US: ["qwertyuiop[", "asdfghjkl;'", "zxcvbnm,./"],
-  };
-  const layout = layouts[keyboardLayout];
+type Keymap = Record<string, KeymapEntry>;
 
-  return {
-    [layout[0][0]]: { default: "そ", shift: "ぁ", side: "left" }, // q
-    [layout[0][1]]: { default: "こ", shift: "ひ", side: "left" }, // w
-    [layout[0][2]]: { default: "し", shift: "ほ", side: "left" }, // e
-    [layout[0][3]]: { default: "て", shift: "ふ", side: "left" }, // r
-    [layout[0][4]]: { default: "ょ", shift: "め", side: "left" }, // t
+const keymap = {
+  KeyQ: { default: "そ", shift: "ぁ", side: "left" },
+  KeyW: { default: "こ", shift: "ひ", side: "left" },
+  KeyE: { default: "し", shift: "ほ", side: "left" },
+  KeyR: { default: "て", shift: "ふ", side: "left" },
+  KeyT: { default: "ょ", shift: "め", side: "left" },
+  KeyY: { default: "つ", shift: "ぬ", side: "right" },
+  KeyU: { default: "ん", shift: "え", side: "right" },
+  KeyI: { default: "い", shift: "み", side: "right" },
+  KeyO: { default: "の", shift: "や", side: "right" },
+  KeyP: { default: "り", shift: "ぇ", side: "right" },
+  BracketLeft: { default: "ち", shift: "[", side: "right" },
 
-    [layout[1][0]]: { default: "は", shift: "ぃ", side: "left" }, // a
-    [layout[1][1]]: { default: "か", shift: "を", side: "left" }, // s
-    [layout[1][2]]: { default: "", shift: "ら", side: "left" }, // d
-    [layout[1][3]]: { default: "と", shift: "あ", side: "left" }, // f
-    [layout[1][4]]: { default: "た", shift: "よ", side: "left" }, // g
+  KeyA: { default: "は", shift: "ぃ", side: "left" },
+  KeyS: { default: "か", shift: "を", side: "left" },
+  KeyD: { default: "", shift: "ら", side: "left" },
+  KeyF: { default: "と", shift: "あ", side: "left" },
+  KeyG: { default: "た", shift: "よ", side: "left" },
+  KeyH: { default: "く", shift: "ま", side: "right" },
+  KeyJ: { default: "う", shift: "お", side: "right" },
+  KeyK: { default: "", shift: "も", side: "right" },
+  KeyL: { default: "゛", shift: "わ", side: "right" },
+  Semicolon: { default: "き", shift: "ゆ", side: "right" },
+  Quote: { default: "れ", shift: "]", side: "right" },
 
-    [layout[2][0]]: { default: "す", shift: "ぅ", side: "left" }, // z
-    [layout[2][1]]: { default: "け", shift: "へ", side: "left" }, // x
-    [layout[2][2]]: { default: "に", shift: "せ", side: "left" }, // c
-    [layout[2][3]]: { default: "な", shift: "ゅ", side: "left" }, // v
-    [layout[2][4]]: { default: "さ", shift: "ゃ", side: "left" }, // b
-
-    [layout[0][5]]: { default: "つ", shift: "ぬ", side: "right" }, // y
-    [layout[0][6]]: { default: "ん", shift: "え", side: "right" }, // u
-    [layout[0][7]]: { default: "い", shift: "み", side: "right" }, // i
-    [layout[0][8]]: { default: "の", shift: "や", side: "right" }, // o
-    [layout[0][9]]: { default: "り", shift: "ぇ", side: "right" }, // p
-    [layout[0][10]]: { default: "ち", shift: "[", side: "right" }, // [ or @
-
-    [layout[1][5]]: { default: "く", shift: "ま", side: "right" }, // h
-    [layout[1][6]]: { default: "う", shift: "お", side: "right" }, // j
-    [layout[1][7]]: { default: "", shift: "も", side: "right" }, // k
-    [layout[1][8]]: { default: "゛", shift: "わ", side: "right" }, // l
-    [layout[1][9]]: { default: "き", shift: "ゆ", side: "right" }, // ;
-    [layout[1][10]]: { default: "れ", shift: "]", side: "right" }, // ' or :
-
-    [layout[2][5]]: { default: "っ", shift: "む", side: "right" }, // n
-    [layout[2][6]]: { default: "る", shift: "ろ", side: "right" }, // m
-    [layout[2][7]]: { default: ",", shift: "ね", side: "right" }, //,
-    [layout[2][8]]: { default: ".", shift: "-", side: "right" }, // .
-    [layout[2][9]]: { default: "゜", shift: "ぉ", side: "right" }, // /
-  };
-}
-
-const keymaps = {
-  JIS: createKeymap("JIS"),
-  US: createKeymap("US"),
-};
+  KeyZ: { default: "す", shift: "ぅ", side: "left" },
+  KeyX: { default: "け", shift: "へ", side: "left" },
+  KeyC: { default: "に", shift: "せ", side: "left" },
+  KeyV: { default: "な", shift: "ゅ", side: "left" },
+  KeyB: { default: "さ", shift: "ゃ", side: "left" },
+  KeyN: { default: "っ", shift: "む", side: "right" },
+  KeyM: { default: "る", shift: "ろ", side: "right" },
+  Comma: { default: ",", shift: "ね", side: "right" },
+  Period: { default: ".", shift: "-", side: "right" },
+  Slash: { default: "゜", shift: "ぉ", side: "right" },
+  IntlRo: { default: "・", shift: "", side: "right" },
+} satisfies Keymap;
 
 type State = {
   shift: "none" | "left" | "right";
 };
 
+type ValidKeys = keyof typeof keymap;
+
 /**
  * 配列の範囲内のキー入力かどうかを判定する
  */
-function makeIsValidKey(layout: KeyboardLayoutKind) {
-  const keymap = keymaps[layout];
-
-  return function isValidKey(key: string): boolean {
+function makeIsValidKey(keymap: Keymap) {
+  return function isValidKey(key: string): key is ValidKeys {
     return Object.keys(keymap).includes(key);
   };
 }
@@ -79,21 +62,19 @@ function makeIsValidKey(layout: KeyboardLayoutKind) {
 /**
  * キー入力を処理する
  */
-function makeProcess(layout: KeyboardLayoutKind) {
-  const keymap = keymaps[layout];
-
-  const process: InputProcessor<State, string> = ({ state, key }) => {
+function makeProcess(keymap: Keymap) {
+  const process: InputProcessor<State, ValidKeys> = ({ state, key }) => {
     if (state.shift === "none") {
-      if (key === "d") {
+      if (key === "KeyD") {
         return { state: { shift: "left" }, event: undefined };
-      } else if (key === "k") {
+      } else if (key === "KeyK") {
         return { state: { shift: "right" }, event: undefined };
       } else {
         const event = convertKanaToEvent(keymap[key].default);
         return { state: { shift: "none" }, event };
       }
     } else if (state.shift === "left") {
-      if (key === "d") {
+      if (key === "KeyD") {
         // シフト2回押してもシフトのまま何もしない
         return { state: { shift: "left" }, event: undefined };
       } else {
@@ -110,7 +91,7 @@ function makeProcess(layout: KeyboardLayoutKind) {
         }
       }
     } else {
-      if (key === "k") {
+      if (key === "KeyK") {
         // シフト2回押してもシフトのまま何もしない
         return { state: { shift: "right" }, event: undefined };
       } else {
@@ -133,19 +114,17 @@ function makeProcess(layout: KeyboardLayoutKind) {
 }
 
 export type TsukiLayout = {
-  process: InputProcessor<State, string>;
-  isValidKey: (key: string) => boolean;
+  process: InputProcessor<State, ValidKeys>;
+  isValidKey: (key: string) => key is ValidKeys;
   updateKeyGuide: UpdateKeyGuide;
 };
 
 /**
  * 月配列用のキー処理関数
  */
-export function makeTsukiLayout(
-  keyboardLayout: KeyboardLayoutKind
-): TsukiLayout {
-  const process = makeProcess(keyboardLayout);
-  const isValidKey = makeIsValidKey(keyboardLayout);
+export function makeTsukiLayout(): TsukiLayout {
+  const process = makeProcess(keymap);
+  const isValidKey = makeIsValidKey(keymap);
 
   return {
     process,

--- a/src/layouts/tsuki-2-263.ts
+++ b/src/layouts/tsuki-2-263.ts
@@ -2,7 +2,11 @@ import { InputProcessor } from "../input-processor";
 import { convertKanaToEvent } from "../typing-event";
 import { updateKeyGuide, UpdateKeyGuide } from "./tsuki-2-263-keyguide";
 
-type KeymapEntry = { default: string; shift: string; side: "left" | "right" };
+type KeymapEntry = {
+  default: string;
+  shift: string | undefined;
+  side: "left" | "right";
+};
 
 type Keymap = Record<string, KeymapEntry>;
 
@@ -41,7 +45,7 @@ const keymap = {
   Comma: { default: ",", shift: "ね", side: "right" },
   Period: { default: ".", shift: "-", side: "right" },
   Slash: { default: "゜", shift: "ぉ", side: "right" },
-  IntlRo: { default: "・", shift: "", side: "right" },
+  IntlRo: { default: "・", shift: undefined, side: "right" },
 } satisfies Keymap;
 
 type State = {

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -23,33 +23,6 @@
           </label>
         </div>
 
-        <!-- キーボード配列選択 -->
-        <div class="setting-group">
-          <h3 class="setting-title">キーボード配列</h3>
-          <div class="radio-group">
-            <label class="radio-label">
-              <input
-                type="radio"
-                name="keyboard-layout"
-                value="JIS"
-                id="keyboard-jis"
-              />
-              <span class="radio-button"></span>
-              <span class="radio-text">JIS配列</span>
-            </label>
-            <label class="radio-label">
-              <input
-                type="radio"
-                name="keyboard-layout"
-                value="US"
-                id="keyboard-us"
-              />
-              <span class="radio-button"></span>
-              <span class="radio-text">US配列</span>
-            </label>
-          </div>
-        </div>
-
         <!-- かな配列選択 -->
         <div class="setting-group">
           <h3 class="setting-title">かな配列</h3>

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -2,36 +2,22 @@ import "./style.css";
 import { Settings, defaultSettings } from "../settings";
 
 const enabledToggle = document.getElementById(
-  "enabled-toggle"
-) as HTMLInputElement;
-const keyboardJisRadio = document.getElementById(
-  "keyboard-jis"
-) as HTMLInputElement;
-const keyboardUsRadio = document.getElementById(
-  "keyboard-us"
+  "enabled-toggle",
 ) as HTMLInputElement;
 const kanaLayoutSelect = document.getElementById(
-  "kana-layout"
+  "kana-layout",
 ) as HTMLSelectElement;
 
 function loadSettings() {
-  chrome.storage.sync.get(
-    ["enabled", "keyboardLayout", "kanaLayout"],
-    (result) => {
-      const settings: Settings = {
-        enabled: result.enabled ?? defaultSettings.enabled,
-        keyboardLayout: result.keyboardLayout ?? defaultSettings.keyboardLayout,
-        kanaLayout: result.kanaLayout ?? defaultSettings.kanaLayout,
-      };
+  chrome.storage.sync.get(["enabled", "kanaLayout"], (result) => {
+    const settings: Settings = {
+      enabled: result.enabled ?? defaultSettings.enabled,
+      kanaLayout: result.kanaLayout ?? defaultSettings.kanaLayout,
+    };
 
-      enabledToggle.checked = settings.enabled;
-      (settings.keyboardLayout === "JIS"
-        ? keyboardJisRadio
-        : keyboardUsRadio
-      ).checked = true;
-      kanaLayoutSelect.value = settings.kanaLayout;
-    }
-  );
+    enabledToggle.checked = settings.enabled;
+    kanaLayoutSelect.value = settings.kanaLayout;
+  });
 }
 
 function saveSetting(key: keyof Settings, value: Settings[keyof Settings]) {
@@ -40,18 +26,6 @@ function saveSetting(key: keyof Settings, value: Settings[keyof Settings]) {
 
 enabledToggle.addEventListener("change", () => {
   saveSetting("enabled", enabledToggle.checked);
-});
-
-keyboardJisRadio.addEventListener("change", () => {
-  if (keyboardJisRadio.checked) {
-    saveSetting("keyboardLayout", "JIS");
-  }
-});
-
-keyboardUsRadio.addEventListener("change", () => {
-  if (keyboardUsRadio.checked) {
-    saveSetting("keyboardLayout", "US");
-  }
 });
 
 kanaLayoutSelect.addEventListener("change", () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,11 +1,9 @@
 export interface Settings {
   enabled: boolean;
-  keyboardLayout: "JIS" | "US";
   kanaLayout: "tsuki";
 }
 
 export const defaultSettings: Settings = {
   enabled: true,
-  keyboardLayout: "JIS",
   kanaLayout: "tsuki",
 };

--- a/src/typing-event.ts
+++ b/src/typing-event.ts
@@ -92,7 +92,7 @@ function isValidKana(kana: string): kana is ValidKana {
  * かなを出力するためのイベントに変換する
  */
 export function convertKanaToEvent(
-  kana: string | undefined
+  kana: string | undefined,
 ): TypingEvent | undefined {
   if (kana === undefined) return undefined;
 

--- a/src/typing-event.ts
+++ b/src/typing-event.ts
@@ -93,7 +93,7 @@ function isValidKana(kana: string): kana is ValidKana {
  */
 export function convertKanaToEvent(kana: string): TypingEvent {
   if (!isValidKana(kana)) {
-    throw new Error(`${kana}に対応していません`);
+    throw new Error(`"${kana}"に対応していません`);
   }
 
   return kanaToJisKanaMap[kana];

--- a/src/typing-event.ts
+++ b/src/typing-event.ts
@@ -91,7 +91,11 @@ function isValidKana(kana: string): kana is ValidKana {
 /**
  * かなを出力するためのイベントに変換する
  */
-export function convertKanaToEvent(kana: string): TypingEvent {
+export function convertKanaToEvent(
+  kana: string | undefined
+): TypingEvent | undefined {
+  if (kana === undefined) return undefined;
+
   if (!isValidKana(kana)) {
     throw new Error(`"${kana}"に対応していません`);
   }


### PR DESCRIPTION
fix #9
fix #10

## 変更点

- キー入力判定処理をKeyboardEvent.keyからKeyboardEvent.codeを使うように変更
- 中黒（・）を入力できるように修正
- JIS/US配列の選択が不要になったため削除
- ついでにウ゛のキーガイドが表示されるように修正

### 説明

中黒を入力できるようにしました。月配列キーマップから抜けていたことが原因だったので追加しました。

また既存の実装はKeyboardEvent.keyを元に判定しており、KeyboardEvent.codeを使った方が良さそうだったため修正しました。

また、それに伴ってJIS/US配列の選択が不要になったため、関連する処理を削除しました。